### PR TITLE
Make request available to handler

### DIFF
--- a/lib/passport-dummy/strategy.js
+++ b/lib/passport-dummy/strategy.js
@@ -65,7 +65,7 @@ Strategy.prototype.authenticate = function(req) {
     }
 
     var self = this;
-    this.verify(function(err, user) {
+    this.verify.call(req, function(err, user) {
         if (err) { return self.error(err); }
         if (!user) { return self.fail(); }
         self.success(user, {});


### PR DESCRIPTION
This would allow the dummy authentication handler to mimic more complex providers.
