### PR TITLE
Fix compatibility with Passport 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/lib/passport-dummy/index.js
+++ b/lib/passport-dummy/index.js
@@ -7,7 +7,7 @@ var Strategy = require('./strategy');
 /**
  * Framework version.
  */
-exports.version = '0.1.0';
+exports.version = require('../../package.json').version;
 
 /**
  * Expose constructors.

--- a/lib/passport-dummy/strategy.js
+++ b/lib/passport-dummy/strategy.js
@@ -1,7 +1,7 @@
 /**
 * Module dependencies.
 */
-var passport = require('passport')
+var passport = require('passport-strategy')
 , util = require('util');
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adrian Rossouw <adrian@developmentseed.org> (http://developmentseed.org/)",
   "main": "./lib/passport-dummy",
   "dependencies": {
-    "passport": ">= 0.1.1"
+    "passport-strategy": "^1.0.0"
   },
   "engines": { "node": ">= 0.4.0" },
   "keywords": ["passport", "auth", "authentication", "identity"]


### PR DESCRIPTION
One has to depend on the `passport-strategy` package rather than the main package now to avoid conflicts between Passport versions (errors like: `TypeError: Cannot set property 'user' of undefined`). This PR fixes that.

(This PR also+ ensures that the exposed version matches the one in `package.json` + adds a `.gitignore` for `/node_modules` – I can remove these extra changes from the PR if you want)

After this has been merged I would suggest publishing a `1.0.0` release of this module. It works well for what it is supposed to do, I've used it in the dev environments of many projects of mine to avoid Twitter/GitHub login locally, so no need for a sub-`1.0.0` version as I see it.

If you want help, feel free to add me to the module here and on NPM and I can merge and publish this fix myself if you perhaps no longer have an active interest in the module.
